### PR TITLE
Fix test data path from hard-coded absolute to relative

### DIFF
--- a/query/src/event_segmentation.rs
+++ b/query/src/event_segmentation.rs
@@ -789,7 +789,7 @@ mod tests {
         )?;
 
         let _prov = MemTable::try_new(schema.clone(), vec![vec![batch]])?;
-        let path = "/Users/ravlio/work/rust/exprtree/tests/events.csv";
+        let path = "../tests/events.csv";
 
         let schema = events_schema();
         let options = CsvReadOptions::new().schema(&schema);


### PR DESCRIPTION
The tests for `event_segmentation` fail because path to test data is hard-coded.